### PR TITLE
[infra]: stg 환경 배포 환경 구축 및 자동화 (ECS + EC2)

### DIFF
--- a/.github/workflows/DeployOnSTG.yml
+++ b/.github/workflows/DeployOnSTG.yml
@@ -1,0 +1,86 @@
+name: Deploy on STG Server (Amazon ECS)
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: community-stg
+  ECS_SERVICE: community-service
+  ECS_CLUSTER: gloddy-ecs-stg
+  ECS_TASK_DEFINITION: task-definition-stg.json
+
+  CONTAINER_NAME: springboot
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS }}
+          aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -f Dockerfile_STG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ env.ECS_TASK_DEFINITION }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/Dockerfile_STG
+++ b/Dockerfile_STG
@@ -1,0 +1,20 @@
+FROM openjdk:17.0-slim
+
+EXPOSE 8080
+
+ARG PROJECT_DIRECTORY=/build
+WORKDIR $PROJECT_DIRECTORY
+
+ARG JAR_FILE_PATH=bootstrap/build/libs/bootstrap-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE_PATH} app.jar
+
+ENV TZ=Asia/Seoul
+
+EXPOSE 8080
+
+RUN  apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+RUN wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+
+ENTRYPOINT ["java", "-javaagent:dd-java-agent.jar", "-Ddd.profiling.enabled=true", "-XX:FlightRecorderOptions=stackdepth=256", "-Ddd.appsec.enabled=true", "-Ddd.iast.enabled=true", "-Ddd.logs.injection=true", "-Ddd.jmxfetch.enabled=true", "-Ddd.service=gloddy-community", "-Ddd.env=staging", "-jar", "app.jar"]

--- a/community-in-api/src/main/kotlin/gloddy/controller/health/HealthCheckController.kt
+++ b/community-in-api/src/main/kotlin/gloddy/controller/health/HealthCheckController.kt
@@ -1,0 +1,15 @@
+package gloddy.controller.health
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthCheckController {
+
+    @Operation(hidden = true)
+    @GetMapping("/health")
+    fun healthCheck(): String {
+        return "healthy"
+    }
+}

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -1,11 +1,11 @@
 {
-  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/community-stg:1",
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/community-stg:3",
   "containerDefinitions": [
     {
       "name": "springboot",
       "image": "750773866215.dkr.ecr.ap-northeast-2.amazonaws.com/community-stg:latest",
       "cpu": 389,
-      "memory": 768,
+      "memory": 614,
       "portMappings": [
         {
           "name": "springboot-8080-tcp",
@@ -41,7 +41,7 @@
       "name": "community-datadog-agent-stg",
       "image": "public.ecr.aws/datadog/agent:latest",
       "cpu": 102,
-      "memory": 205,
+      "memory": 102,
       "portMappings": [],
       "essential": false,
       "environment": [
@@ -79,9 +79,10 @@
     }
   ],
   "family": "community-stg",
+  "taskRoleArn": "arn:aws:iam::750773866215:role/ec2-role-for-ec2",
   "executionRoleArn": "arn:aws:iam::750773866215:role/ecsTaskExecutionRole",
   "networkMode": "awsvpc",
-  "revision": 1,
+  "revision": 3,
   "volumes": [],
   "status": "ACTIVE",
   "requiresAttributes": [
@@ -101,6 +102,9 @@
       "name": "ecs.capability.env-files.s3"
     },
     {
+      "name": "com.amazonaws.ecs.capability.task-iam-role"
+    },
+    {
       "name": "ecs.capability.execution-role-ecr-pull"
     },
     {
@@ -115,19 +119,18 @@
   ],
   "placementConstraints": [],
   "compatibilities": [
-    "EC2",
-    "FARGATE"
+    "EC2"
   ],
   "requiresCompatibilities": [
     "EC2"
   ],
   "cpu": "512",
-  "memory": "1024",
+  "memory": "819",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"
   },
-  "registeredAt": "2024-01-09T09:31:39.064Z",
+  "registeredAt": "2024-01-10T10:22:08.410Z",
   "registeredBy": "arn:aws:iam::750773866215:root",
   "tags": []
 }

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -1,0 +1,133 @@
+{
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/community-stg:1",
+  "containerDefinitions": [
+    {
+      "name": "springboot",
+      "image": "750773866215.dkr.ecr.ap-northeast-2.amazonaws.com/community-stg:latest",
+      "cpu": 389,
+      "memory": 768,
+      "portMappings": [
+        {
+          "name": "springboot-8080-tcp",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::gloddy-env/env/gloddy-community-stg.env",
+          "type": "s3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "true",
+          "awslogs-group": "/ecs/community-stg",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      }
+    },
+    {
+      "name": "community-datadog-agent-stg",
+      "image": "public.ecr.aws/datadog/agent:latest",
+      "cpu": 102,
+      "memory": 205,
+      "portMappings": [],
+      "essential": false,
+      "environment": [
+        {
+          "name": "DD_SITE",
+          "value": "us5.datadoghq.com"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
+          "value": "true"
+        }
+      ],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::gloddy-env/env/datadog.env",
+          "type": "s3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "true",
+          "awslogs-group": "/ecs/community-datadog-stg",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      }
+    }
+  ],
+  "family": "community-stg",
+  "executionRoleArn": "arn:aws:iam::750773866215:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "revision": 1,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+    {
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+    },
+    {
+      "name": "ecs.capability.env-files.s3"
+    },
+    {
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "name": "ecs.capability.task-eni"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "EC2",
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "EC2"
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "registeredAt": "2024-01-09T09:31:39.064Z",
+  "registeredBy": "arn:aws:iam::750773866215:root",
+  "tags": []
+}


### PR DESCRIPTION
resolved #6 
## 작업한 일
- 기존 `ECS` STG Cluster에 태스크 정의(EC2)를 생성하여 **커뮤니티 서비스**를 생성하였습니다.
  - 작업 도중 많은 트러블 슈팅이 있었네요..(Fargate 환경이 아니라 EC2 환경으로 처음 시도하다보니 EC2에 ECS-agent, SSMagent등을 다 설치하고 그 과정에서 환경변수 빠트린거 하나하나 찾고.. 공식문서 왜캐 불친절한지 ㅠㅠ. 정리는 노션에 해두었습니다!)
- 그리고 기존에는 AWS API Gateway -> ALB -> 기존 서버이었는데 기존 구조를 그대로 유지하고 ALB 단에서 리스너(커뮤니티 요청 리스너)를 생성하여 분기처리하도록 하였습니다.
- 커뮤니티 서버 APM(Datadog) 환경을 구축하였습니다.
- github actions를 활용하여 배포 자동화 환경을 구축하였습니다.