### PR TITLE
[Fix]: LocalDateTime Response 포맷터 변경(12시간제 -> 24시간제)

### DIFF
--- a/.github/workflows/DeployOnSTG.yml
+++ b/.github/workflows/DeployOnSTG.yml
@@ -1,4 +1,4 @@
-name: Deploy on STG Server (Amazon ECS)
+name: Deploy on PRD Server (Amazon ECS)
 
 on:
   pull_request:

--- a/community-application/src/main/kotlin/gloddy/core/util/DateTimeUtil.kt
+++ b/community-application/src/main/kotlin/gloddy/core/util/DateTimeUtil.kt
@@ -4,5 +4,5 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter.*
 
 fun LocalDateTime.toResponse(): String =
-    this.format(ofPattern("yyyy-MM-dd hh:mm"))
+    this.format(ofPattern("yyyy-MM-dd HH:mm"))
         .replace(" ", "T")


### PR DESCRIPTION
## Issue
- resolved #21 

## 작업한 이유
- `LocalDateTime` Response 포맷터가 12시간제로 되어 있어 응답이 원하는 결과로 반환하지 않는다.

## 작업한 일
- `LocalDateTime` 포맷터 12시간제(hh) -> 24시간제(HH)로 변경